### PR TITLE
Bugfix in masterMenu to correct the bug when you call twice the metisMenu() function

### DIFF
--- a/dist/metisMenu.js
+++ b/dist/metisMenu.js
@@ -100,7 +100,7 @@
         },
 
         remove: function() {
-            this.element.off("." + pluginName);
+            this.element.find('a').off("." + pluginName);
             this.element.removeData(pluginName);
         }
 


### PR DESCRIPTION
I need to call twice the function to init the masterMenu in same page, without reload it, and it was bugging in .off() because it wasn't remove the handler of a elements.

I know that in other branch you have rebuild the structure of plugin, but here is a little adjust that i need to do for have the master working on my project.
