### PR TITLE
add option *iconSelect*

### DIFF
--- a/dist/metisMenu.js
+++ b/dist/metisMenu.js
@@ -80,7 +80,8 @@
     collapseInClass: 'in',
     collapsingClass: 'collapsing',
     onTransitionStart: false,
-    onTransitionEnd: false
+    onTransitionEnd: false,
+    iconSelect: false
   };
 
   MetisMenu.prototype.init = function() {
@@ -116,11 +117,23 @@
         .addClass('doubleTapToGo');
     }
 
-    this
-      .$element
-      .find('li')
-      .has('ul')
-      .children('a')
+    if (this.options.iconSelect) {
+        var elm = this
+            .$element
+            .find('li')
+            .has('ul')
+            .children('a')
+            .find('span');
+    } else {
+        var elm = this
+            .$element
+            .find('li')
+            .has('ul')
+            .children('a');
+    }
+
+
+    elm
       .on('click.metisMenu', function(e) {
         var self = $(this);
         var $parent = self.parent('li');

--- a/dist/metisMenu.js
+++ b/dist/metisMenu.js
@@ -136,7 +136,7 @@
     elm
       .on('click.metisMenu', function(e) {
         var self = $(this);
-        var $parent = self.parent('li');
+        var $parent = self.closest('li');
         var $list = $parent.children('ul');
         if($this.options.preventDefault){
           e.preventDefault();


### PR DESCRIPTION
Hi,

I have just added option "iconSelect".
I got the issue that I can't go to link on parent node, each time I clicked on parent, it just expand and dont go to link that I added.

So I add the option 'iconSelect', its function is:
 - when you click on <a> -> the browser will go to link of <a>
 - when you click on icon next to <a> title, the menu will expand its childs

If you see this function is helpful for your plugin, just merge into your branch.

Regards and thank so much for your cool plugin,