### PR TITLE
Do not show child menus with .mini-navbar class

### DIFF
--- a/src/metisMenu.js
+++ b/src/metisMenu.js
@@ -127,7 +127,7 @@
         if($this.options.preventDefault){
           e.preventDefault();
         }
-        if(self.attr('aria-disabled') === 'true'){
+        if(self.attr('aria-disabled') === 'true' || self.parents('.mini-navbar').length > 0){
             return;
         }
         if ($parent.hasClass(activeClass) && !$this.options.doubleTapToGo) {


### PR DESCRIPTION
Do not show child menus when the .mini-navbar class is set on any parent class. Used for the INSPINIA theme where the mini navbar will otherwise show he menu on the right hand side and also try to collapse the menu.