### PR TITLE
fix Menu failed to remove collapsing class

### DIFF
--- a/src/metisMenu.js
+++ b/src/metisMenu.js
@@ -286,7 +286,7 @@ const MetisMenu = (($) => {
         return;
       }
 
-      _el
+      (_el.height() == 0 || _el.css('display') == 'none') ? complete() : _el
         .height(0)
         .one(Util.TRANSITION_END, complete);
 


### PR DESCRIPTION
if the menu item is set to display none or height 0 already , 
 transition end event was not fired , metis was not able to remove collapsing class.

add detection.

https://github.com/onokumus/metisMenu/issues/96