### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ npm install --save-dev @types/metismenu
       OR
 
   ```html
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/jquery.metismenu/2.7.0/metisMenu.min.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/metismenu@2.7.0/dist/metisMenu.min.css">
   ```
 
 2. Include jQuery
@@ -92,7 +92,7 @@ $ npm install --save-dev @types/metismenu
   ```
       OR
   ```html
-  <script src="//cdn.jsdelivr.net/jquery/2.2.4/jquery.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/jquery@2.2.4/dist/jquery.min.js"></script>
   ```
 
 3. Include metisMenu plugin's code
@@ -102,7 +102,7 @@ $ npm install --save-dev @types/metismenu
   ```
       OR
   ```html
-  <script src="//cdn.jsdelivr.net/jquery.metismenu/2.7.0/metisMenu.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/metismenu@2.7.0/dist/metisMenu.min.js"></script>
   ```
 
 4. Add class `metismenu` to unordered list


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/metismenu.

Feel free to ping me if you have any questions regarding this change.