### PR TITLE
refactor(js): replace node.js events to customevents 

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "nodemon": "^1.17.5",
     "npm-run-all": "^4.1.3",
     "postcss-cli": "^5.0.0",
-    "postcss-header": "^1.0.0",
     "prettier": "^1.13.5",
     "rollup": "^0.60.7",
     "rollup-plugin-babel": "^4.0.0-beta.5",

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,5 +1,11 @@
 import { IMMOptions } from "./interface";
 
+export type MetisMenuEvents =
+  | "show.metisMenu"
+  | "shown.metisMenu"
+  | "hide.metisMenu"
+  | "hidden.metisMenu";
+
 export const Default: IMMOptions = {
   activeClass: "active",
   collapseClass: "collapse",


### PR DESCRIPTION
The NodeJs events package has been removed. CustomEvent was used instead.
The number of rows has been reduced. Now, code is too lightweight.

BREAKING CHANGE: yes