### PR TITLE
Make jquery a peer dependency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,5 +6,9 @@
         "es6": true,
         "jquery": true
     },
+    "rules": {
+        "import/no-unresolved": ["error", { "ignore": ["jquery"] }],
+        "import/extensions": ["error", { "jquery": "never" }]
+    },
     "extends": "airbnb-base"
 }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
       "twbuttons"
     ]
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": "^3.3.1"
   }
 }


### PR DESCRIPTION
jquery was added as a dependency in 8e060073cc56d015eb369b2ab12d9729a165fe0c. Unfortunately this causes issues when using metismenu with a different version of jquery, because the `node_modules` directory has this structure:

```
node_modules/
├── jquery/
└── metismenu/
    └── jquery/
```

In the application I'm working on, this causes the output generated by webpack to include two versions of jquery, and breaks metismenu because it's referencing a different version than the rest of my application.

This pull request changes jquery to be a peer dependency to indicate that it should be provided by users of metismenu, which will ensure that only one version of jquery is bundled.